### PR TITLE
Docs: Remove extra fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,9 @@ row -->
 | Table Relationships             | ✅ ❌     |       |
 | Views                           | ✅ ❌     |       |
 | Remote Relationships            | ✅ ❌     |       |
-| Custom Fields                   | ✅ ❌     |       |
 | Mutations                       | ✅ ❌     |       |
 | Distinct                        | ✅ ❌     |       |
 | Enums                           | ✅ ❌     |       |
-| Naming Conevntions              | ✅ ❌     |       |
 | Default Values                  | ✅ ❌     |       |
 | User-defined Functions          | ✅ ❌     |       |
 
@@ -60,7 +58,6 @@ row -->
 | Views                           | ✅ ❌     |       |
 | Distinct                        | ✅ ❌     |       |
 | Remote Relationships            | ✅ ❌     |       |
-| Custom Fields                   | ✅ ❌     |       |
 | Mutations                       | ✅ ❌     |       |
 -->
 


### PR DESCRIPTION
Based on feedback, these fields are carry-overs from v2 and don't apply